### PR TITLE
ghc-xcprogs: runghc strips binaries.

### DIFF
--- a/recipes-devtools/ghc/ghc-xcprog.inc
+++ b/recipes-devtools/ghc/ghc-xcprog.inc
@@ -1,2 +1,4 @@
 require ghc-pkg.inc
 require ghc-xc.inc
+
+INSANE_SKIP_${PN} += "already-stripped"


### PR DESCRIPTION
--disable-binary-stripping does not seem to be implemented in this
version, anyway might as well hide this warning like the other ones.
