### PR TITLE
Always use ghc option to exclude rpath.

### DIFF
--- a/classes/ghc.bbclass
+++ b/classes/ghc.bbclass
@@ -15,12 +15,6 @@ SETUPFILE = "$([ -f Setup.lhs ] && echo Setup.lhs || echo Setup.hs)"
 LOCAL_GHC_PACKAGE_DATABASE = "${S}/local-packages.db"
 export GHC_PACKAGE_PATH = "${LOCAL_GHC_PACKAGE_DATABASE}:"
 
-# ghc libs have (and always had) broken rpath disable sanity checking for now
-INSANE_SKIP_${PN} = "rpaths"
-INSANE_SKIP_${PN}-dev = "rpaths"
-INSANE_SKIP_${PN}-dbg = "rpaths"
-
-
 do_configure_prepend() {
     if [ ! -e "${LOCAL_GHC_PACKAGE_DATABASE}" ];then
         ghc-pkg init "${LOCAL_GHC_PACKAGE_DATABASE}"

--- a/recipes-devtools/ghc/ghc-pkg.inc
+++ b/recipes-devtools/ghc/ghc-pkg.inc
@@ -160,10 +160,10 @@ do_configure() {
         # The previous instance of this in devshell was also changed
         CFLAGS="${CFLAGS} -std=gnu89" \
         CPP="${CPP}" \
-        ${RUNSETUP} configure --package-db=${LOCAL_GHC_PACKAGE_DATABASE} --enable-shared --with-compiler=ghc-${GHC_VERSION} --ghc-options='-pgmc ./ghc-cc -pgml ./ghc-ld' --with-gcc=./ghc-cc --prefix=${prefix} --libsubdir=ghc-local/\$pkgid ${CABAL_CONFIGURE_EXTRA_OPTS}
+        ${RUNSETUP} configure --package-db=${LOCAL_GHC_PACKAGE_DATABASE} --enable-shared --with-compiler=ghc-${GHC_VERSION} --ghc-options='-dynload deploy -pgmc ./ghc-cc -pgml ./ghc-ld' --with-gcc=./ghc-cc --prefix=${prefix} --libsubdir=ghc-local/\$pkgid ${CABAL_CONFIGURE_EXTRA_OPTS}
 }
 
 do_compile() {
-        ${RUNSETUP} --ghc-options='-pgmc ./ghc-cc -pgml ./ghc-ld' --with-gcc=./ghc-cc build
+        ${RUNSETUP} --ghc-options='-dynload deploy -pgmc ./ghc-cc -pgml ./ghc-ld' --with-gcc=./ghc-cc build
 }
 

--- a/recipes-devtools/ghc/ghc-pkg.inc
+++ b/recipes-devtools/ghc/ghc-pkg.inc
@@ -18,11 +18,7 @@ SETUPFILE = "$([ -f Setup.lhs ] && echo Setup.lhs || echo Setup.hs)"
 LOCAL_GHC_PACKAGE_DATABASE = "${S}/local-packages.db"
 export GHC_PACKAGE_PATH = "${LOCAL_GHC_PACKAGE_DATABASE}:"
 
-# ghc libs have (and always had) broken rpath disable sanity checking for now
-INSANE_SKIP_${PN} = "rpaths"
-INSANE_SKIP_${PN}-dev = "rpaths staticdev"
-INSANE_SKIP_${PN}-dbg = "rpaths"
-
+INSANE_SKIP_${PN}-dev = "staticdev"
 
 do_configure_prepend_class-target() {
     # This is prepend for the target

--- a/recipes-devtools/ghc/ghc-xc.inc
+++ b/recipes-devtools/ghc/ghc-xc.inc
@@ -9,5 +9,5 @@ do_configure() {
         # The previous instance of this in devshell was also changed
         CFLAGS="${CFLAGS}" \
         CPP="${CPP}" \
-	${RUNSETUP} configure ${EXTRA_CABAL_CONF} --package-db=${LOCAL_GHC_PACKAGE_DATABASE} --ghc-options='-pgml ./ghc-ld' --with-hsc2hs-ld="${S}/ghc-ld"  --enable-shared --with-compiler=ghc-${GHC_VERSION} --prefix=${prefix} --extra-include-dirs="${STAGING_INCDIR}" --extra-lib-dirs="${STAGING_LIBDIR}" --libsubdir=ghc-local/\$pkgid --with-gcc=./ghc-cc
+	${RUNSETUP} configure ${EXTRA_CABAL_CONF} --package-db=${LOCAL_GHC_PACKAGE_DATABASE} --ghc-options='-dynload deploy -pgml ./ghc-ld' --with-hsc2hs-ld="${S}/ghc-ld"  --enable-shared --with-compiler=ghc-${GHC_VERSION} --prefix=${prefix} --extra-include-dirs="${STAGING_INCDIR}" --extra-lib-dirs="${STAGING_LIBDIR}" --libsubdir=ghc-local/\$pkgid --with-gcc=./ghc-cc
 }


### PR DESCRIPTION
GHC embeds the build machine's absolute paths to each
dynamically-loaded library as the rpath. This causes the resulting
binaries to first look in the wrong locations for libraries (and
possibly cause SELinux denials). OXT-1101