### PR TITLE
OXT-1225: ghc: Missing binutils dependency.

### DIFF
--- a/recipes-devtools/ghc/files/binutils-2.24-config-guard.patch
+++ b/recipes-devtools/ghc/files/binutils-2.24-config-guard.patch
@@ -1,0 +1,17 @@
+Index: ghc-6.12.3/rts/Printer.c
+===================================================================
+--- ghc-6.12.3.orig/rts/Printer.c
++++ ghc-6.12.3/rts/Printer.c
+@@ -808,6 +808,12 @@ static void printZcoded( const char *raw
+ */
+ #ifdef USING_LIBBFD
+ 
++#ifndef PACKAGE
++# define PACKAGE "ghc"
++#endif
++#ifndef PACKAGE_VERSION
++# define PACKAGE_VERSION "6.12.3"
++#endif
+ #include <bfd.h>
+ 
+ /* Fairly ad-hoc piece of code that seems to filter out a lot of

--- a/recipes-devtools/ghc/ghc-6.12.3.inc
+++ b/recipes-devtools/ghc/ghc-6.12.3.inc
@@ -7,6 +7,7 @@ SRC_URI = " \
     file://gcc-4.9-fomit-frame-pointer.patch \
     file://use-order-only-constraints-for-directories.patch \
     file://linux-host-os-need-pthread.patch \
+    file://binutils-2.24-config-guard.patch \
 "
 SRC_URI[md5sum] = "4c2663c2eff833d7b9f39ef770eefbd6"
 SRC_URI[sha256sum] = "6cbdbe415011f2c7d15e4d850758d8d393f70617b88cb3237d2c602bb60e5e68"

--- a/recipes-devtools/ghc/ghc-common.inc
+++ b/recipes-devtools/ghc/ghc-common.inc
@@ -3,4 +3,8 @@ HOMEPAGE = "https://www.haskell.org/ghc/download_ghc_6_12_3"
 LICENSE = "GHCL"
 SECTION = "devel/haskell"
 
+DEPENDS += " \
+    binutils \
+"
+
 S = "${WORKDIR}/ghc-${PV}"

--- a/recipes-devtools/hackage/hkg-haxml_1.20.2.bb
+++ b/recipes-devtools/hackage/hkg-haxml_1.20.2.bb
@@ -9,7 +9,7 @@ SRC_URI[md5sum] = "9635c348e70c0446e74783e7c267050c"
 SRC_URI[sha256sum] = "c32c10b95446ecb938dc6cd34585187efd3fcb4b21f7d0c7cbd646ba94c87516"
 DEPENDS += "hkg-polyparse"
 
-INSANE_SKIP_${PN} = "already-stripped"
-INSANE_SKIP_${PN}-native = "already-stripped"
+INSANE_SKIP_${PN} += "already-stripped"
+INHIBIT_SYSROOT_STRIP = "1"
 
 PR = "r1"


### PR DESCRIPTION
bfd.h is used in rts/Printer.c, but recent versions of this header guard
against PACKAGE and PACKAGE_VERSION not being defined before its
inclusion (https://sourceware.org/bugzilla/show_bug.cgi?id=14072).

This will have ghc-{runtime,native} build if bintuils-native has not
been built yet, so race.

Add the missing dependency to binutils in ghc recipe include, and handle
building with recent versions of binutils.