### PR TITLE
haskell: disable runghc strip by default.

### DIFF
--- a/classes/haskell.bbclass
+++ b/classes/haskell.bbclass
@@ -106,6 +106,7 @@ do_configure() {
     ${RUNGHC} Setup.*hs clean --verbose
     ${RUNGHC} Setup.*hs configure \
         ${EXTRA_CABAL_CONF} \
+        --disable-executable-stripping \
         --package-db="${GHC_PACKAGE_DATABASE}" \
         --ghc-options='-dynload sysdep
                        -pgmc ./ghc-cc

--- a/recipes-devtools/hackage/hkg-haxml_1.20.2.bb
+++ b/recipes-devtools/hackage/hkg-haxml_1.20.2.bb
@@ -8,5 +8,3 @@ inherit hackage
 SRC_URI[md5sum] = "9635c348e70c0446e74783e7c267050c"
 SRC_URI[sha256sum] = "c32c10b95446ecb938dc6cd34585187efd3fcb4b21f7d0c7cbd646ba94c87516"
 DEPENDS += "hkg-polyparse"
-
-PR = "r1"

--- a/recipes-devtools/hackage/hkg-haxml_1.20.2.bb
+++ b/recipes-devtools/hackage/hkg-haxml_1.20.2.bb
@@ -9,6 +9,4 @@ SRC_URI[md5sum] = "9635c348e70c0446e74783e7c267050c"
 SRC_URI[sha256sum] = "c32c10b95446ecb938dc6cd34585187efd3fcb4b21f7d0c7cbd646ba94c87516"
 DEPENDS += "hkg-polyparse"
 
-INHIBIT_SYSROOT_STRIP = "1"
-
 PR = "r1"

--- a/recipes-devtools/hackage/hkg-haxml_1.20.2.bb
+++ b/recipes-devtools/hackage/hkg-haxml_1.20.2.bb
@@ -9,7 +9,6 @@ SRC_URI[md5sum] = "9635c348e70c0446e74783e7c267050c"
 SRC_URI[sha256sum] = "c32c10b95446ecb938dc6cd34585187efd3fcb4b21f7d0c7cbd646ba94c87516"
 DEPENDS += "hkg-polyparse"
 
-INSANE_SKIP_${PN} += "already-stripped"
 INHIBIT_SYSROOT_STRIP = "1"
 
 PR = "r1"

--- a/recipes-devtools/hackage/hkg-vhd_0.2.bb
+++ b/recipes-devtools/hackage/hkg-vhd_0.2.bb
@@ -14,7 +14,3 @@ DEPENDS += " \
     hkg-cereal \
     hkg-text \
 "
-
-INSANE_SKIP_${PN} = "already-stripped"
-
-PR = "r1"


### PR DESCRIPTION
runghc will strip binaries by default. This is not expected by
bitbake/OE.