### PR TITLE
OXT-880: OE upgrade to pyro

### DIFF
--- a/classes/haskell.bbclass
+++ b/classes/haskell.bbclass
@@ -8,7 +8,7 @@ SECTION = "devel/haskell"
 DEPENDS_append_class-target += " \
     ghc-runtime \
 "
-DEPENDS += " \
+DEPENDS_append = " \
     ghc-native \
 "
 PACKAGES = " \
@@ -18,23 +18,23 @@ PACKAGES = " \
     ${PN}-dbg \
     ${PN}-dev \
 "
-FILES_${PN} =+ " \
+FILES_${PN}_append = " \
     ${libdir}/${HPN}-${HPV}/ghc-*/libH*.so \
     ${libdir}/ghc-*/package.conf.d/*.conf \
     ${bindir}/* \
 "
-FILES_${PN}-doc =+ " \
+FILES_${PN}-doc_append = " \
     ${datadir}/* \
 "
-FILES_${PN}-staticdev =+ " \
+FILES_${PN}-staticdev_append = " \
     ${libdir}/${HPN}-${HPV}/ghc-*/libHS*.a \
 "
-FILES_${PN}-dbg =+ " \
+FILES_${PN}-dbg_append = " \
     ${libdir}/${HPN}-${HPV}/ghc-*/*.o \
     ${libdir}/${HPN}-${HPV}/ghc-*/.debug \
     ${prefix}/src/debug \
 "
-FILES_${PN}-dev =+ " \
+FILES_${PN}-dev_append = " \
     ${libdir}/${HPN}-${HPV}/ghc-*/* \
 "
 

--- a/classes/haskell.bbclass
+++ b/classes/haskell.bbclass
@@ -48,13 +48,14 @@ do_update_local_pkg_database() {
     rm -rf "${GHC_PACKAGE_DATABASE}"
     ghc-pkg init "${GHC_PACKAGE_DATABASE}"
 }
-addtask do_update_local_pkg_database before do_configure after do_patch
+# Run after do_prepare_recipe_sysroot to ensure that the recipe's sysroot is
+# populated by every item in DEPENDS before we update the local package
+# database. runghc will not be able to process dependencies otherwise, neither
+# will ghc-pkg be there if not installed on the host.
+addtask do_update_local_pkg_database before do_configure after do_prepare_recipe_sysroot
 do_update_local_pkg_database[doc] = "Put together a local Haskell package database for runghc to use, and amend configuration to match bitbake environment."
-# Ensure that the recipe's sysroot is populated by every item in DEPENDS before
-# we update the local package database. runghc will not be able to process
-# dependencies otherwise, neither will ghc-pkg be there if not installed on the
-# host.
-do_update_local_pkg_database[deptask] = "do_populate_sysroot"
+# See: bitbake.git: 67a7b8b0 build: don't use $B as the default cwd for functions
+do_update_local_pkg_database[dirs] = "${B}"
 
 do_update_local_pkg_database_append_class-target() {
     ghc_version=$(ghc-pkg --version)
@@ -101,6 +102,7 @@ EOF
 }
 addtask do_makeup_wrappers before do_configure after do_patch
 do_makeup_wrappers[doc] = "Generate local wrappers for the compiler to pass bitbake environment through ghc."
+do_makeup_wrappers[dirs] = "${B}"
 
 do_configure() {
     ${RUNGHC} Setup.*hs clean --verbose
@@ -136,6 +138,7 @@ do_local_package_conf() {
 }
 addtask do_local_package_conf before do_install after do_compile
 do_local_package_conf[doc] = "Generate Haskell package configuration."
+do_local_package_conf[dirs] = "${B}"
 
 # Amend the rpath to match target environment. This is because a lot of dynamic
 # libraries will be installed in non-standard sub-directories of ${libdir}.  It
@@ -172,6 +175,7 @@ do_fixup_rpath_class-target() {
 }
 addtask do_fixup_rpath after do_install before do_package
 do_fixup_rpath[doc] = "Amend rpath set by GHC to comply with target's environment."
+do_fixup_rpath[dirs] = "${B}"
 
 do_install() {
     ${RUNGHC} Setup.*hs copy --copy-prefix="${D}/${prefix}" --verbose

--- a/classes/haskell.bbclass
+++ b/classes/haskell.bbclass
@@ -8,7 +8,7 @@ SECTION = "devel/haskell"
 DEPENDS_append_class-target += " \
     ghc-runtime \
 "
-DEPENDS_append_class-native += " \
+DEPENDS += " \
     ghc-native \
 "
 PACKAGES = " \

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -23,3 +23,9 @@ HOSTTOOLS += " \
     ghc \
     ghc-pkg \
 "
+
+# Default is to not build libpseudo 32 bit on 64 bit systems.
+# Due to how the haskell toolchain is setup now, x86_32 tools will eventually
+# be used in a x86_64 environment. This is a work-around for this layer
+# supporting only x86[_64]->x86[_64] builds.
+NO32LIBS = "0"

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -18,3 +18,8 @@ BBFILE_PRIORITY_meta-openxt-haskell-platform = "9"
 LICENSE_PATH += "${LAYERDIR}/files/additional-licenses"
 
 LAYERVERSION_meta-openxt-haskell-platform = "1"
+
+HOSTTOOLS += " \
+    ghc \
+    ghc-pkg \
+"

--- a/recipes-devtools/ghc/files/0001-fix-a-bug-introduced-in-1fb38442d3a55ac92795aa6c5ed4.patch
+++ b/recipes-devtools/ghc/files/0001-fix-a-bug-introduced-in-1fb38442d3a55ac92795aa6c5ed4.patch
@@ -1,0 +1,30 @@
+From 6a6b16df28a0a38ac93a51767fcd743d04097ac5 Mon Sep 17 00:00:00 2001
+From: Simon Marlow <marlowsd@gmail.com>
+Date: Wed, 13 Apr 2011 11:27:20 +0100
+Subject: [PATCH] fix a bug introduced in
+ 1fb38442d3a55ac92795aa6c5ed4df82011df724, symptom was 2047(threaded2) was
+ crashing.
+
+---
+ rts/sm/GC.c | 8 ++++++--
+ 1 file changed, 6 insertions(+), 2 deletions(-)
+
+Index: ghc-6.12.3/rts/sm/GC.c
+===================================================================
+--- ghc-6.12.3.orig/rts/sm/GC.c
++++ ghc-6.12.3/rts/sm/GC.c
+@@ -738,8 +738,12 @@ SET_GCT(gc_threads[0]);
+   // zero the scavenged static object list 
+   if (major_gc) {
+       nat i;
+-      for (i = 0; i < n_gc_threads; i++) {
+-          zero_static_object_list(gc_threads[i]->scavenged_static_objects);
++      if (n_gc_threads == 1) {
++          zero_static_object_list(gct->scavenged_static_objects);
++      } else {
++          for (i = 0; i < n_gc_threads; i++) {
++              zero_static_object_list(gc_threads[i]->scavenged_static_objects);
++          }
+       }
+   }
+ 

--- a/recipes-devtools/ghc/files/0002-Fix-a-retainer-profiling-segfault.patch
+++ b/recipes-devtools/ghc/files/0002-Fix-a-retainer-profiling-segfault.patch
@@ -1,0 +1,24 @@
+From 140aeb3949039cb7df43ac2d7e4a755fb4711879 Mon Sep 17 00:00:00 2001
+From: Ian Lynagh <igloo@earth.li>
+Date: Tue, 19 Oct 2010 13:27:27 +0000
+Subject: [PATCH] Fix a retainer profiling segfault The bitmap type wasn't big
+ enough to hold large bitmaps on 64 bit platforms. Profiling GHC was
+ segfaulting when retainStack was handling a size 33 bitmap.
+
+---
+ rts/RetainerProfile.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+Index: ghc-6.12.3/rts/RetainerProfile.c
+===================================================================
+--- ghc-6.12.3.orig/rts/RetainerProfile.c
++++ ghc-6.12.3/rts/RetainerProfile.c
+@@ -1321,7 +1321,7 @@ retainStack( StgClosure *c, retainer c_c
+     stackElement *oldStackBoundary;
+     StgPtr p;
+     StgRetInfoTable *info;
+-    StgWord32 bitmap;
++    StgWord bitmap;
+     nat size;
+ 
+ #ifdef DEBUG_RETAINER

--- a/recipes-devtools/ghc/files/0003-Run-finalizers-after-updating-the-stable-pointer-tab.patch
+++ b/recipes-devtools/ghc/files/0003-Run-finalizers-after-updating-the-stable-pointer-tab.patch
@@ -1,0 +1,57 @@
+From afabd52e95235ab36c5ad7b3473b5d6a4d58360b Mon Sep 17 00:00:00 2001
+From: Simon Marlow <marlowsd@gmail.com>
+Date: Tue, 10 Aug 2010 13:37:39 +0000
+Subject: [PATCH] Run finalizers *after* updating the stable pointer table
+ (#4221) Silly bug really, we were running the C finalizers while the
+ StablePtr table was still in a partially-updated state during GC, but
+ finalizers are allowed to call freeStablePtr() (via hs_free_fun_ptr(), for
+ example), and chaos ensues.
+
+---
+ rts/sm/GC.c | 19 +++++++++++--------
+ 1 file changed, 11 insertions(+), 8 deletions(-)
+
+Index: ghc-6.12.3/rts/sm/GC.c
+===================================================================
+--- ghc-6.12.3.orig/rts/sm/GC.c
++++ ghc-6.12.3/rts/sm/GC.c
+@@ -750,11 +750,6 @@ SET_GCT(gc_threads[0]);
+   // Reset the nursery
+   resetNurseries();
+ 
+-  // start any pending finalizers 
+-  RELEASE_SM_LOCK;
+-  scheduleFinalizers(cap, old_weak_ptr_list);
+-  ACQUIRE_SM_LOCK;
+-  
+   // send exceptions to any threads which were about to die 
+   RELEASE_SM_LOCK;
+   resurrectThreads(resurrected_threads);
+@@ -764,6 +759,17 @@ SET_GCT(gc_threads[0]);
+   // Update the stable pointer hash table.
+   updateStablePtrTable(major_gc);
+ 
++  // unlock the StablePtr table.  Must be before scheduleFinalizers(),
++  // because a finalizer may call hs_free_fun_ptr() or
++  // hs_free_stable_ptr(), both of which access the StablePtr table.
++  stablePtrPostGC();
++
++  // Start any pending finalizers.  Must be after
++  // updateStablePtrTable() and stablePtrPostGC() (see #4221).
++  RELEASE_SM_LOCK;
++  scheduleFinalizers(cap, old_weak_ptr_list);
++  ACQUIRE_SM_LOCK;
++
+   // check sanity after GC 
+   IF_DEBUG(sanity, checkSanity());
+ 
+@@ -795,9 +801,6 @@ SET_GCT(gc_threads[0]);
+   slop = calcLiveBlocks() * BLOCK_SIZE_W - live;
+   stat_endGC(allocated, live, copied, N, max_copied, avg_copied, slop);
+ 
+-  // unlock the StablePtr table
+-  stablePtrPostGC();
+-
+   // Guess which generation we'll collect *next* time
+   initialise_N(force_major_gc);
+ 

--- a/recipes-devtools/ghc/files/0004-Fix-crash-with-large-objects-7919.patch
+++ b/recipes-devtools/ghc/files/0004-Fix-crash-with-large-objects-7919.patch
@@ -1,0 +1,89 @@
+From d8dd3cf954a9bb77d9caa64290fcea0d1abb32ec Mon Sep 17 00:00:00 2001
+From: Simon Marlow <marlowsd@gmail.com>
+Date: Fri, 24 May 2013 08:30:25 +0100
+Subject: [PATCH] Fix crash with large objects (#7919)
+
+See comments for details.
+---
+ rts/sm/GCUtils.c | 58 ++++++++++++++++++++++++++++++++++++++++++--------------
+ 1 file changed, 44 insertions(+), 14 deletions(-)
+
+Index: ghc-6.12.3/rts/sm/GCUtils.c
+===================================================================
+--- ghc-6.12.3.orig/rts/sm/GCUtils.c
++++ ghc-6.12.3/rts/sm/GCUtils.c
+@@ -162,6 +162,7 @@ push_scanned_block (bdescr *bd, step_wor
+ StgPtr
+ todo_block_full (nat size, step_workspace *ws)
+ {
++    rtsBool urgent_to_push, can_extend;
+     StgPtr p;
+     bdescr *bd;
+ 
+@@ -175,22 +176,51 @@ todo_block_full (nat size, step_workspac
+     ASSERT(bd->link == NULL);
+     ASSERT(bd->step == ws->step);
+ 
+-    // If the global list is not empty, or there's not much work in
+-    // this block to push, and there's enough room in
+-    // this block to evacuate the current object, then just increase
+-    // the limit.
+-    if (!looksEmptyWSDeque(ws->todo_q) || 
+-        (ws->todo_free - bd->u.scan < WORK_UNIT_WORDS / 2)) {
+-        if (ws->todo_free + size < bd->start + bd->blocks * BLOCK_SIZE_W) {
+-            ws->todo_lim = stg_min(bd->start + bd->blocks * BLOCK_SIZE_W,
+-                                   ws->todo_lim + stg_max(WORK_UNIT_WORDS,size));
+-            debugTrace(DEBUG_gc, "increasing limit for %p to %p", bd->start, ws->todo_lim);
+-            p = ws->todo_free;
+-            ws->todo_free += size;
+-            return p;
+-        }
++    // We intentionally set ws->todo_lim lower than the full size of
++    // the block, so that we can push out some work to the global list
++    // and get the parallel threads working as soon as possible.
++    //
++    // So when ws->todo_lim is reached, we end up here and have to
++    // decide whether it's worth pushing out the work we have or not.
++    // If we have enough room in the block to evacuate the current
++    // object, and it's not urgent to push this work, then we just
++    // extend the limit and keep going.  Where "urgent" is defined as:
++    // the global pool is empty, and there's enough work in this block
++    // to make it worth pushing.
++    //
++    urgent_to_push =
++        looksEmptyWSDeque(ws->todo_q) &&
++        (ws->todo_free - bd->u.scan >= WORK_UNIT_WORDS / 2);
++
++    // We can extend the limit for the current block if there's enough
++    // room for the current object, *and* we're not into the second or
++    // subsequent block of a large block.  The second condition occurs
++    // when we evacuate an object that is larger than a block.  In
++    // that case, alloc_todo_block() sets todo_lim to be exactly the
++    // size of the large object, and we don't evacuate any more
++    // objects into this block.  The reason is that the rest of the GC
++    // is not set up to handle objects that start in the second or
++    // later blocks of a group.  We just about manage this in the
++    // nursery (see scheduleHandleHeapOverflow()) so evacuate() can
++    // handle this, but other parts of the GC can't.  We could
++    // probably fix this, but it's a rare case anyway.
++    //
++    can_extend =
++        ws->todo_free + size <= bd->start + bd->blocks * BLOCK_SIZE_W
++        && ws->todo_free < ws->todo_bd->start + BLOCK_SIZE_W;
++
++    if (!urgent_to_push && can_extend)
++    {
++        ws->todo_lim = stg_min(bd->start + bd->blocks * BLOCK_SIZE_W,
++                               ws->todo_lim + stg_max(WORK_UNIT_WORDS,size));
++        debugTrace(DEBUG_gc, "increasing limit for %p to %p",
++                   bd->start, ws->todo_lim);
++        p = ws->todo_free;
++        ws->todo_free += size;
++
++        return p;
+     }
+-    
++
+     gct->copied += ws->todo_free - bd->free;
+     bd->free = ws->todo_free;
+ 

--- a/recipes-devtools/ghc/files/0005-Fix-an-arithmetic-overflow-bug-causing-crashes-with-.patch
+++ b/recipes-devtools/ghc/files/0005-Fix-an-arithmetic-overflow-bug-causing-crashes-with-.patch
@@ -1,0 +1,23 @@
+From bdbb7f57adf98d4826e0c97b5eff9c45ceb3dbf2 Mon Sep 17 00:00:00 2001
+From: Simon Marlow <marlowsd@gmail.com>
+Date: Thu, 24 Jun 2010 10:46:54 +0000
+Subject: [PATCH] Fix an arithmetic overflow bug causing crashes with multi-GB
+ heaps
+
+---
+ rts/sm/BlockAlloc.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+Index: ghc-6.12.3/rts/sm/BlockAlloc.c
+===================================================================
+--- ghc-6.12.3.orig/rts/sm/BlockAlloc.c
++++ ghc-6.12.3/rts/sm/BlockAlloc.c
+@@ -282,7 +282,7 @@ alloc_mega_group (nat mblocks)
+     if (best)
+     {
+         // we take our chunk off the end here.
+-        nat best_mblocks  = BLOCKS_TO_MBLOCKS(best->blocks);
++        StgWord best_mblocks  = BLOCKS_TO_MBLOCKS(best->blocks);
+         bd = FIRST_BDESCR((StgWord8*)MBLOCK_ROUND_DOWN(best) + 
+                           (best_mblocks-mblocks)*MBLOCK_SIZE);
+ 

--- a/recipes-devtools/ghc/files/integer-simple-noinline-pragmas.patch
+++ b/recipes-devtools/ghc/files/integer-simple-noinline-pragmas.patch
@@ -1,0 +1,262 @@
+From cd4d0fbf2e70bb699126848503482790c9570881 Mon Sep 17 00:00:00 2001
+From: Ian Lynagh <igloo@earth.li>
+Date: Tue, 13 Sep 2011 19:19:47 +0100
+Subject: [PATCH] Add NOINLINE pragmas
+
+Stops code size explosions, and allows the built-in rules to fire
+---
+ libraries/integer-simple/GHC/Integer/Type.hs | 38 ++++++++++++++++++++++++++++
+ 1 file changed, 38 insertions(+)
+
+Index: ghc-6.12.3/libraries/integer-simple/GHC/Integer.hs
+===================================================================
+--- ghc-6.12.3.orig/libraries/integer-simple/GHC/Integer.hs
++++ ghc-6.12.3/libraries/integer-simple/GHC/Integer.hs
+@@ -56,16 +56,19 @@ errorInteger = Positive errorPositive
+ errorPositive :: Positive
+ errorPositive = Some 47## None -- Random number
+ 
++{-# NOINLINE smallInteger #-}
+ smallInteger :: Int# -> Integer
+ smallInteger i = if i >=# 0# then wordToInteger (int2Word# i)
+                  else -- XXX is this right for -minBound?
+                       negateInteger (wordToInteger (int2Word# (negateInt# i)))
+ 
++{-# NOINLINE wordToInteger #-}
+ wordToInteger :: Word# -> Integer
+ wordToInteger w = if w `eqWord#` 0##
+                   then Naught
+                   else Positive (Some w None)
+ 
++{-# NOINLINE integerToWord #-}
+ integerToWord :: Integer -> Word#
+ integerToWord (Positive (Some w _)) = w
+ integerToWord (Negative (Some w _)) = 0## `minusWord#` w
+@@ -78,20 +81,24 @@ toInt# i = word2Int# (integerToWord i)
+ #if WORD_SIZE_IN_BITS == 64
+ -- Nothing
+ #elif WORD_SIZE_IN_BITS == 32
++{-# NOINLINE integerToWord64 #-}
+ integerToWord64 :: Integer -> Word64#
+ integerToWord64 i = int64ToWord64# (integerToInt64 i)
+ 
+-word64ToInteger:: Word64# -> Integer
++{-# NOINLINE word64ToInteger #-}
++word64ToInteger :: Word64# -> Integer
+ word64ToInteger w = if w `eqWord64#` wordToWord64# 0##
+                     then Naught
+                     else Positive (word64ToPositive w)
+ 
++{-# NOINLINE integerToInt64 #-}
+ integerToInt64 :: Integer -> Int64#
+ integerToInt64 Naught = intToInt64# 0#
+ integerToInt64 (Positive p) = word64ToInt64# (positiveToWord64 p)
+ integerToInt64 (Negative p)
+     = negateInt64# (word64ToInt64# (positiveToWord64 p))
+ 
++{-# NOINLINE int64ToInteger #-}
+ int64ToInteger :: Int64# -> Integer
+ int64ToInteger i
+  = if i `eqInt64#` intToInt64# 0#
+@@ -112,6 +119,7 @@ negativeOneInteger = Negative onePositiv
+ twoToTheThirtytwoInteger :: Integer
+ twoToTheThirtytwoInteger = Positive twoToTheThirtytwoPositive
+ 
++{-# NOINLINE encodeDoubleInteger #-}
+ encodeDoubleInteger :: Integer -> Int# -> Double#
+ encodeDoubleInteger (Positive ds0) e0 = f 0.0## ds0 e0
+     where f !acc None        (!_) = acc
+@@ -127,6 +135,7 @@ encodeDoubleInteger Naught _ = 0.0##
+ foreign import ccall unsafe "__word_encodeDouble"
+         encodeDouble# :: Word# -> Int# -> Double#
+ 
++{-# NOINLINE encodeFloatInteger #-}
+ encodeFloatInteger :: Integer -> Int# -> Float#
+ encodeFloatInteger (Positive ds0) e0 = f 0.0# ds0 e0
+     where f !acc None        (!_) = acc
+@@ -142,6 +151,7 @@ encodeFloatInteger Naught _ = 0.0#
+ foreign import ccall unsafe "__word_encodeFloat"
+     encodeFloat# :: Word# -> Int# -> Float#
+ 
++{-# NOINLINE decodeFloatInteger #-}
+ decodeFloatInteger :: Float# -> (# Integer, Int# #)
+ decodeFloatInteger f = case decodeFloat_Int# f of
+                        (# mant, exp #) -> (# smallInteger mant, exp #)
+@@ -149,6 +159,7 @@ decodeFloatInteger f = case decodeFloat_
+ -- XXX This could be optimised better, by either (word-size dependent)
+ -- using single 64bit value for the mantissa, or doing the multiplication
+ -- by just building the Digits directly
++{-# NOINLINE decodeDoubleInteger #-}
+ decodeDoubleInteger :: Double# -> (# Integer, Int# #)
+ decodeDoubleInteger d
+  = case decodeDouble_2Int# d of
+@@ -158,16 +169,19 @@ decodeDoubleInteger d
+              `plusInteger` wordToInteger mantLow),
+           exp #)
+ 
++{-# NOINLINE doubleFromInteger #-}
+ doubleFromInteger :: Integer -> Double#
+ doubleFromInteger Naught = 0.0##
+ doubleFromInteger (Positive p) = doubleFromPositive p
+ doubleFromInteger (Negative p) = negateDouble# (doubleFromPositive p)
+ 
++{-# NOINLINE floatFromInteger #-}
+ floatFromInteger :: Integer -> Float#
+ floatFromInteger Naught = 0.0#
+ floatFromInteger (Positive p) = floatFromPositive p
+ floatFromInteger (Negative p) = negateFloat# (floatFromPositive p)
+ 
++{-# NOINLINE andInteger #-}
+ andInteger :: Integer -> Integer -> Integer
+ Naught     `andInteger` (!_)       = Naught
+ (!_)       `andInteger` Naught     = Naught
+@@ -211,6 +225,7 @@ Negative x `andInteger` Negative y = let
+                                          z' = succPositive z
+                                      in digitsToNegativeInteger z'
+ 
++{-# NOINLINE orInteger #-}
+ orInteger :: Integer -> Integer -> Integer
+ Naught     `orInteger` (!i)       = i
+ (!i)       `orInteger` Naught     = i
+@@ -241,6 +256,7 @@ Negative x `orInteger` Negative y = let
+                                         z' = succPositive z
+                                     in digitsToNegativeInteger z'
+ 
++{-# NOINLINE xorInteger #-}
+ xorInteger :: Integer -> Integer -> Integer
+ Naught     `xorInteger` (!i)       = i
+ (!i)       `xorInteger` Naught     = i
+@@ -269,14 +285,17 @@ Negative x `xorInteger` Negative y = let
+                                          z = x' `xorDigits` y'
+                                      in digitsToInteger z
+ 
++{-# NOINLINE complementInteger #-}
+ complementInteger :: Integer -> Integer
+ complementInteger x = negativeOneInteger `minusInteger` x
+ 
++{-# NOINLINE shiftLInteger #-}
+ shiftLInteger :: Integer -> Int# -> Integer
+ shiftLInteger (Positive p) i = Positive (shiftLPositive p i)
+ shiftLInteger (Negative n) i = Negative (shiftLPositive n i)
+ shiftLInteger Naught       _ = Naught
+ 
++{-# NOINLINE shiftRInteger #-}
+ shiftRInteger :: Integer -> Int# -> Integer
+ shiftRInteger (Positive p)   i = shiftRPositive p i
+ shiftRInteger j@(Negative _) i
+@@ -293,11 +312,13 @@ flipBitsDigits :: Digits -> Digits
+ flipBitsDigits None = None
+ flipBitsDigits (Some w ws) = Some (not# w) (flipBitsDigits ws)
+ 
++{-# NOINLINE negateInteger #-}
+ negateInteger :: Integer -> Integer
+ negateInteger (Positive p) = Negative p
+ negateInteger (Negative p) = Positive p
+ negateInteger Naught       = Naught
+ 
++{-# NOINLINE plusInteger #-}
+ plusInteger :: Integer -> Integer -> Integer
+ Positive p1 `plusInteger` Positive p2 = Positive (p1 `plusPositive` p2)
+ Negative p1 `plusInteger` Negative p2 = Negative (p1 `plusPositive` p2)
+@@ -309,9 +330,11 @@ Negative p1 `plusInteger` Positive p2 =
+ Naught      `plusInteger` (!i)        = i
+ (!i)        `plusInteger` Naught      = i
+ 
++{-# NOINLINE minusInteger #-}
+ minusInteger :: Integer -> Integer -> Integer
+ i1 `minusInteger` i2 = i1 `plusInteger` negateInteger i2
+ 
++{-# NOINLINE timesInteger #-}
+ timesInteger :: Integer -> Integer -> Integer
+ Positive p1 `timesInteger` Positive p2 = Positive (p1 `timesPositive` p2)
+ Negative p1 `timesInteger` Negative p2 = Positive (p1 `timesPositive` p2)
+@@ -319,6 +342,7 @@ Positive p1 `timesInteger` Negative p2 =
+ Negative p1 `timesInteger` Positive p2 = Negative (p1 `timesPositive` p2)
+ (!_)        `timesInteger` (!_)        = Naught
+ 
++{-# NOINLINE divModInteger #-}
+ divModInteger :: Integer -> Integer -> (# Integer, Integer #)
+ n `divModInteger` d =
+     case n `quotRemInteger` d of
+@@ -328,6 +352,7 @@ n `divModInteger` d =
+             then (# q `minusInteger` oneInteger, r `plusInteger` d #)
+             else (# q, r #)
+ 
++{-# NOINLINE quotRemInteger #-}
+ quotRemInteger :: Integer -> Integer -> (# Integer, Integer #)
+ Naught      `quotRemInteger` (!_)        = (# Naught, Naught #)
+ (!_)        `quotRemInteger` Naught
+@@ -345,14 +370,17 @@ Negative p1 `quotRemInteger` Negative p2
+                                            (# q, r #) ->
+                                                (# q, negateInteger r #)
+ 
++{-# NOINLINE quotInteger #-}
+ quotInteger :: Integer -> Integer -> Integer
+ x `quotInteger` y = case x `quotRemInteger` y of
+                     (# q, _ #) -> q
+ 
++{-# NOINLINE remInteger #-}
+ remInteger :: Integer -> Integer -> Integer
+ x `remInteger` y = case x `quotRemInteger` y of
+                    (# _, r #) -> r
+ 
++{-# NOINLINE compareInteger #-}
+ compareInteger :: Integer -> Integer -> Ordering
+ Positive x `compareInteger` Positive y = x `comparePositive` y
+ Positive _ `compareInteger` (!_)       = GT
+@@ -361,46 +389,55 @@ Naught     `compareInteger` Negative _ =
+ Negative x `compareInteger` Negative y = y `comparePositive` x
+ (!_)       `compareInteger` (!_)       = LT
+ 
++{-# NOINLINE eqInteger #-}
+ eqInteger :: Integer -> Integer -> Bool
+ x `eqInteger` y = case x `compareInteger` y of
+                   EQ -> True
+                   _ -> False
+ 
++{-# NOINLINE neqInteger #-}
+ neqInteger :: Integer -> Integer -> Bool
+ x `neqInteger` y = case x `compareInteger` y of
+                    EQ -> False
+                    _ -> True
+ 
++{-# NOINLINE ltInteger #-}
+ ltInteger :: Integer -> Integer -> Bool
+ x `ltInteger` y = case x `compareInteger` y of
+                   LT -> True
+                   _ -> False
+ 
++{-# NOINLINE gtInteger #-}
+ gtInteger :: Integer -> Integer -> Bool
+ x `gtInteger` y = case x `compareInteger` y of
+                   GT -> True
+                   _ -> False
+ 
++{-# NOINLINE leInteger #-}
+ leInteger :: Integer -> Integer -> Bool
+ x `leInteger` y = case x `compareInteger` y of
+                   GT -> False
+                   _ -> True
+ 
++{-# NOINLINE geInteger #-}
+ geInteger :: Integer -> Integer -> Bool
+ x `geInteger` y = case x `compareInteger` y of
+                   LT -> False
+                   _ -> True
+ 
++{-# NOINLINE absInteger #-}
+ absInteger :: Integer -> Integer
+ absInteger (Negative x) = Positive x
+ absInteger x = x
+ 
++{-# NOINLINE signumInteger #-}
+ signumInteger :: Integer -> Integer
+ signumInteger (Negative _) = negativeOneInteger
+ signumInteger Naught       = Naught
+ signumInteger (Positive _) = oneInteger
+ 
+ -- XXX This isn't a great hash function
++{-# NOINLINE hashInteger #-}
+ hashInteger :: Integer -> Int#
+ hashInteger (!_) = 42#
+ 

--- a/recipes-devtools/ghc/files/use-order-only-constraints-for-directories.patch
+++ b/recipes-devtools/ghc/files/use-order-only-constraints-for-directories.patch
@@ -410,3 +410,17 @@ Index: ghc-6.12.3/utils/runghc/ghc.mk
  	"$(CP)" $< $@
  endif
  
+Index: ghc-6.12.3/utils/hsc2hs/ghc.mk
+===================================================================
+--- ghc-6.12.3.orig/utils/hsc2hs/ghc.mk
++++ ghc-6.12.3/utils/hsc2hs/ghc.mk
+@@ -45,8 +45,7 @@ endif
+ # dependency to ensure these libs are built before we invoke hsc2hs:
+ $(HSC2HS_INPLACE) : $(OTHER_LIBS)
+ 
+-$(utils/hsc2hs_template) : utils/hsc2hs/template-hsc.h
+-	"$(MKDIRHIER)" $(dir $@)
++$(utils/hsc2hs_template) : utils/hsc2hs/template-hsc.h | $$(dir $$@)/.
+ 	"$(CP)" $< $@
+ 
+ endif

--- a/recipes-devtools/ghc/ghc-6.12.3.inc
+++ b/recipes-devtools/ghc/ghc-6.12.3.inc
@@ -18,5 +18,8 @@ do_compile() {
 }
 
 do_install() {
+    # There is a race somewhere triggered when installing utils/hsc2hs/template-hsc.h
+    # Work-around until upgrade.
+    install -m 0755 -d ${D}/${libdir}/${BPN}-${PV}
     oe_runmake install DESTDIR="${D}"
 }

--- a/recipes-devtools/ghc/ghc-6.12.3.inc
+++ b/recipes-devtools/ghc/ghc-6.12.3.inc
@@ -8,6 +8,12 @@ SRC_URI = " \
     file://use-order-only-constraints-for-directories.patch \
     file://linux-host-os-need-pthread.patch \
     file://binutils-2.24-config-guard.patch \
+    file://integer-simple-noinline-pragmas.patch \
+    file://0001-fix-a-bug-introduced-in-1fb38442d3a55ac92795aa6c5ed4.patch \
+    file://0002-Fix-a-retainer-profiling-segfault.patch \
+    file://0003-Run-finalizers-after-updating-the-stable-pointer-tab.patch \
+    file://0004-Fix-crash-with-large-objects-7919.patch \
+    file://0005-Fix-an-arithmetic-overflow-bug-causing-crashes-with-.patch \
 "
 SRC_URI[md5sum] = "4c2663c2eff833d7b9f39ef770eefbd6"
 SRC_URI[sha256sum] = "6cbdbe415011f2c7d15e4d850758d8d393f70617b88cb3237d2c602bb60e5e68"

--- a/recipes-devtools/ghc/ghc-runtime_6.12.3.bb
+++ b/recipes-devtools/ghc/ghc-runtime_6.12.3.bb
@@ -40,3 +40,10 @@ DEPENDS += " \
 do_configure() {
     ./configure --prefix=${prefix} --enable-shared
 }
+
+do_sysroot_ghc_pkg_db() {
+    ghc-pkg recache
+}
+addtask do_sysroot_ghc_pkg_db before do_configure after do_prepare_recipe_sysroot
+do_sysroot_ghc_pkg_db[doc] = "Amend the paths in the package database local to the recipes' sysroot."
+do_sysroot_ghc_pkg_db[dirs] = "${B}"

--- a/recipes-devtools/pseudo/pseudo_1.%.bbappend
+++ b/recipes-devtools/pseudo/pseudo_1.%.bbappend
@@ -2,4 +2,3 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/patches:"
 SRC_URI += " \
     file://use-python2.patch \
 "
-NO32LIBS = "0"


### PR DESCRIPTION
Amend the layer to be used against OE 2.3 (Pyro).
Points of interest:
- Expose required `HOSTTOOLS`;
- Add 32bit libspeudo since GHC 6 in this layer will use 32bit tools.

# Dependencies:
See https://github.com/OpenXT/xenclient-oe/pull/830