### PR TITLE
STABLE-8: OXT-1317: haskell: do_update_local_pkg_database depends.

### DIFF
--- a/classes/haskell.bbclass
+++ b/classes/haskell.bbclass
@@ -53,6 +53,7 @@ do_update_local_pkg_database() {
 # database. runghc will not be able to process dependencies otherwise, neither
 # will ghc-pkg be there if not installed on the host.
 addtask do_update_local_pkg_database before do_configure after do_prepare_recipe_sysroot
+do_update_local_pkg_database[depends] = "${PN}:do_unpack"
 do_update_local_pkg_database[doc] = "Put together a local Haskell package database for runghc to use, and amend configuration to match bitbake environment."
 # See: bitbake.git: 67a7b8b0 build: don't use $B as the default cwd for functions
 do_update_local_pkg_database[dirs] = "${B}"


### PR DESCRIPTION
do_update_local_pkg_database needs to be run after both
do_prepare_recipe_sysroot and do_unpack completed.

(cherry picked from commit 80cf6f7be9165890e84cae153e86594f8e74f502)
Master PR: https://github.com/OpenXT/meta-openxt-haskell-platform/pull/10