### PR TITLE
x86_64: [ghc] Include upstream patches for x64 support

### DIFF
--- a/recipes-devtools/ghc/files/0006-stdcall-x86-64.patch
+++ b/recipes-devtools/ghc/files/0006-stdcall-x86-64.patch
@@ -1,0 +1,34 @@
+commit 521157f905926556eaa02a8fbb2f0645efe24a80
+Author: David M Peixotto <dmp@rice.edu>
+Date:   Thu Oct 20 09:18:19 2011 -0500
+
+    Ignore stdcall c-call in native codegen on x86_64
+    
+    The stdcall calling convention is not supported on x86_64.
+    When an ffi import requests stdcall, a warning is issued as
+    desired by #3336. However, the native codegen was still
+    generating code that expected the callee to cleanup the
+    stack arguments when calling a c function that requests
+    stdcall.
+    
+    This patch changes the codegen to actually use the ccall
+    calling convention as intended.
+    
+    Signed-off-by: David Terei <davidterei@gmail.com>
+
+diff --git a/compiler/nativeGen/X86/CodeGen.hs b/compiler/nativeGen/X86/CodeGen.hs
+index 458f379380..19bef8f29b 100644
+--- a/compiler/nativeGen/X86/CodeGen.hs
++++ b/compiler/nativeGen/X86/CodeGen.hs
+@@ -1766,8 +1766,9 @@ genCCall64 target dest_regs args =
+     let call = callinsns `appOL`
+                toOL (
+ 			-- Deallocate parameters after call for ccall;
+-			-- but not for stdcall (callee does it)
+-                  (if cconv == StdCallConv || real_size==0 then [] else 
++			-- stdcall has callee do it, but is not supported on
++			-- x86_64 target (see #3336)
++                  (if real_size==0 then [] else 
+		   [ADD (intSize wordWidth) (OpImm (ImmInt real_size)) (OpReg esp)])
+                   ++
+                   [DELTA (delta + real_size)]

--- a/recipes-devtools/ghc/files/0007-x64-more-stack.patch
+++ b/recipes-devtools/ghc/files/0007-x64-more-stack.patch
@@ -1,0 +1,19 @@
+commit 0e0130b74f36a2571fed5123c853163ca01ad7ae
+Author: Malcolm.Wallace@cs.york.ac.uk <unknown>
+Date:   Tue Dec 1 03:37:45 2009 +0000
+
+    x86_64 requires more stack
+
+diff --git a/libraries/base/Makefile.nhc98 b/libraries/base/Makefile.nhc98
+index a3e6fc43f2..d11e1518df 100644
+--- a/libraries/base/Makefile.nhc98
++++ b/libraries/base/Makefile.nhc98
+@@ -1,7 +1,7 @@
+ THISPKG	= base
+ SEARCH	= -I$(TOPDIR)/targets/$(MACHINE) -Iinclude \
+ 	  -I../../prelude/PreludeIO -I../../prelude/`$(LOCAL)harch`
+-EXTRA_H_FLAGS   = -H4M -K3M
++EXTRA_H_FLAGS   = -H4M -K6M
+ EXTRA_C_FLAGS   = -D__NHC__
+ EXTRA_HBC_FLAGS = -H16M -A1M
+ 

--- a/recipes-devtools/ghc/files/0008-7919-large-objects.patch
+++ b/recipes-devtools/ghc/files/0008-7919-large-objects.patch
@@ -1,0 +1,48 @@
+commit 7cf87dfbf93f9839fa1e3b66a0233ac86f85a5f7
+Author: Simon Marlow <smarlow@fb.com>
+Date:   Thu Jul 30 07:34:43 2015 -0700
+
+    Fix #7919 (again)
+    
+    Summary:
+    The fix is a bit clunky, and is perhaps not the best fix, but I'm not
+    sure how much work it would be to fix it the other way (see comments
+    for more info).
+
+commit d8dd3cf954a9bb77d9caa64290fcea0d1abb32ec
+Author: Simon Marlow <marlowsd@gmail.com>
+Date:   Fri May 24 08:30:25 2013 +0100
+
+    Fix crash with large objects (#7919)
+
+
+Adapated from the above commits to compile on ghc-6.12.3.
+
+Index: ghc-6.12.3/rts/sm/GCUtils.c
+===================================================================
+--- ghc-6.12.3.orig/rts/sm/GCUtils.c
++++ ghc-6.12.3/rts/sm/GCUtils.c
+@@ -139,7 +139,8 @@ push_scanned_block (bdescr *bd, step_wor
+     ASSERT(bd->step == ws->step);
+     ASSERT(bd->u.scan == bd->free);
+ 
+-    if (bd->start + bd->blocks * BLOCK_SIZE_W - bd->free > WORK_UNIT_WORDS)
++    if (bd->blocks == 1 && 
++        bd->start + BLOCK_SIZE_W - bd->free > WORK_UNIT_WORDS)
+     {
+         // a partially full block: put it on the part_list list.
+         bd->link = ws->part_list;
+@@ -236,8 +237,11 @@ todo_block_full (nat size, step_workspac
+         // then there would be enough room to copy the current object.
+         if (bd->u.scan == bd->free)
+         {
+-            ASSERT(bd->free != bd->start);
+-            push_scanned_block(bd, ws);
++            if (bd->free == bd->start) {
++                freeGroup(bd);
++            } else {
++                push_scanned_block(bd, ws);
++            }
+         }
+         // Otherwise, push this block out to the global list.
+         else 

--- a/recipes-devtools/ghc/files/gcc-4.9-fomit-frame-pointer.patch
+++ b/recipes-devtools/ghc/files/gcc-4.9-fomit-frame-pointer.patch
@@ -11,3 +11,12 @@ index 92ce6eb..da6b79b 100644
  StgRun(StgFunPtr f, StgRegTable *basereg) {
  
      unsigned char space[ RESERVED_C_STACK_BYTES + 4*sizeof(void *) ];
+@@ -204,7 +204,7 @@
+ 
+ extern StgRegTable * StgRun(StgFunPtr f, StgRegTable *basereg);
+ 
+-static void GNUC3_ATTRIBUTE(used)
++static void GNUC3_ATTRIBUTE(used) __attribute__((optimize("-fomit-frame-pointer")))
+ StgRunIsImplementedInAssembler(void)
+ {
+     __asm__ volatile (

--- a/recipes-devtools/ghc/ghc-6.12.3.inc
+++ b/recipes-devtools/ghc/ghc-6.12.3.inc
@@ -14,6 +14,9 @@ SRC_URI = " \
     file://0003-Run-finalizers-after-updating-the-stable-pointer-tab.patch \
     file://0004-Fix-crash-with-large-objects-7919.patch \
     file://0005-Fix-an-arithmetic-overflow-bug-causing-crashes-with-.patch \
+    file://0006-stdcall-x86-64.patch \
+    file://0007-x64-more-stack.patch \
+    file://0008-7919-large-objects.patch \
 "
 SRC_URI[md5sum] = "4c2663c2eff833d7b9f39ef770eefbd6"
 SRC_URI[sha256sum] = "6cbdbe415011f2c7d15e4d850758d8d393f70617b88cb3237d2c602bb60e5e68"


### PR DESCRIPTION
  0008-7919-large-objects.patch is directly responsible for mitigating
  a segfault in the GHC runtime, but the other two patches should be
  included as well as they address bugs in GHC on x86_64. The bugs may
  or may not manifest, but it is good practice to include them anyway.
 
  OXT-1528

Signed-off-by: Chris Rogers <rogersc@ainfosec.com>