### PR TITLE
OXT-1706: ghc-6.12.3: no-PIE binaries.

### DIFF
--- a/recipes-devtools/ghc/files/build.mk
+++ b/recipes-devtools/ghc/files/build.mk
@@ -1,6 +1,6 @@
-SRC_HC_OPTS        = -H64m -O0 -fasm
-GhcStage1HcOpts    = -O -fasm
-GhcStage2HcOpts    = -O0 -fasm
+SRC_HC_OPTS        = -H64m -O0 -fasm -optc-no-pie -optl-no-pie -optP-no-pie
+GhcStage1HcOpts    = -O -fasm -optc-no-pie -optl-no-pie -optP-no-pie
+GhcStage2HcOpts    = -O0 -fasm -optc-no-pie -optl-no-pie -optP-no-pie
 GhcLibHcOpts       = -O -fasm
 SplitObjs          = NO
 HADDOCK_DOCS       = NO

--- a/recipes-devtools/ghc/files/compile-ghc-with-no-pie.patch
+++ b/recipes-devtools/ghc/files/compile-ghc-with-no-pie.patch
@@ -1,0 +1,309 @@
+ghc-native uses some pre-compiled code to build itself.
+That pre-compiled code was built a long time ago, without the -pie gcc option,
+that probably didn't even exist back then.
+
+More recent compilers/distros use -pie by default, which breaks the linking of
+most ghc-native components.
+Forcing everything to compile with -no-pie fixes the issue.
+
+What should be a one-liner actually ends up taking all the patching below,
+thanks to the ghc build-system...
+Some of it might actually be redundant, but figuring out which ones can be
+removed would take a lot of time (mostly waiting for ghc-native to compile),
+while redundancy doesn't hurt anything.
+
+--- a/aclocal.m4
++++ b/aclocal.m4
+@@ -1235,7 +1235,7 @@ if test ! -f utils/ghc-pwd/ghc-pwd && te
+   rm -f *.hi
+   rm -f ghc-pwd
+   rm -f ghc-pwd.exe
+-  "$WithGhc" -v0 --make ghc-pwd -o ghc-pwd
++  "$WithGhc" -v0 -optc-no-pie -optl-no-pie -optP-no-pie --make ghc-pwd -o ghc-pwd
+   cd ../..
+ fi
+ 
+--- a/configure
++++ b/configure
+@@ -3122,7 +3122,7 @@ if test ! -f utils/ghc-pwd/ghc-pwd && te
+   rm -f *.hi
+   rm -f ghc-pwd
+   rm -f ghc-pwd.exe
+-  "$WithGhc" -v0 --make ghc-pwd -o ghc-pwd
++  "$WithGhc" -v0 -optc-no-pie -optl-no-pie -optP-no-pie --make ghc-pwd -o ghc-pwd
+   cd ../..
+ fi
+ 
+--- a/utils/ghc-cabal/ghc.mk
++++ b/utils/ghc-cabal/ghc.mk
+@@ -26,7 +26,7 @@ $(GHC_CABAL_DIR)/dist/build/tmp/ghc-caba
+ $(GHC_CABAL_DIR)/dist/build/tmp/ghc-cabal$(exeext): $(wildcard libraries/Cabal/Distribution/*.hs)
+ 
+ $(GHC_CABAL_DIR)/dist/build/tmp/ghc-cabal$(exeext): $(GHC_CABAL_DIR)/ghc-cabal.hs | $$(dir $$@)/. bootstrapping/.
+-	"$(GHC)" $(SRC_HC_OPTS) --make $(GHC_CABAL_DIR)/ghc-cabal.hs -o $@ \
++	"$(GHC)" $(SRC_HC_OPTS) -optc-no-pie -optl-no-pie -optP-no-pie --make $(GHC_CABAL_DIR)/ghc-cabal.hs -o $@ \
+ 	       -Wall $(WERROR) \
+ 	       -DCABAL_VERSION=$(CABAL_VERSION) \
+ 	       -odir  bootstrapping \
+@@ -53,6 +53,7 @@ $(eval $(call all-target,$(GHC_CABAL_DIR
+ 
+ $(GHC_CABAL_DIR)_dist-dummy-ghc_MODULES = dummy-ghc
+ $(GHC_CABAL_DIR)_dist-dummy-ghc_PROG    = dummy-ghc$(exeext)
++$(GHC_CABAL_DIR)_dist-dummy-ghc_HC_OPTS = -optc-no-pie -optl-no-pie -optP-no-pie
+ 
+ # depend on project.mk, so we pick up the new version number if it changes.
+ $(GHC_CABAL_DIR)/dist-dummy-ghc/build/dummy-ghc.hs : $(GHC_CABAL_DIR)/ghc.mk mk/project.mk | $$(dir $$@)/.
+@@ -87,6 +88,6 @@ $(GHC_CABAL_DIR)/dist-dummy-ghc/build/du
+ 
+ # We don't build dummy-ghc with Cabal, so we need to pass -package
+ # flags manually
+-utils/ghc-cabal_dist-dummy-ghc_HC_OPTS = -package process
++utils/ghc-cabal_dist-dummy-ghc_HC_OPTS = -package process -optc-no-pie -optl-no-pie -optP-no-pie
+ $(eval $(call build-prog,utils/ghc-cabal,dist-dummy-ghc,0))
+ 
+--- a/utils/unlit/ghc.mk
++++ b/utils/unlit/ghc.mk
+@@ -14,6 +14,7 @@ utils/unlit_dist_C_SRCS  = unlit.c
+ utils/unlit_dist_PROG    = $(GHC_UNLIT_PGM)
+ utils/unlit_dist_TOPDIR  = YES
+ utils/unlit_dist_INSTALL = YES
++utils/unlit_dist_HC_OPTS = -optc-no-pie -optl-no-pie -optP-no-pie
+ 
+ $(eval $(call build-prog,utils/unlit,dist,0))
+ 
+--- a/utils/hsc2hs/ghc.mk
++++ b/utils/hsc2hs/ghc.mk
+@@ -18,8 +18,8 @@ $(eval $(call build-prog,utils/hsc2hs,di
+ utils/hsc2hs_dist_MODULES += Paths_hsc2hs
+ utils/hsc2hs_dist-install_MODULES = $(utils/hsc2hs_dist_MODULES)
+ 
+-utils/hsc2hs_dist_HC_OPTS         += -DNEW_GHC_LAYOUT
+-utils/hsc2hs_dist-install_HC_OPTS += -DNEW_GHC_LAYOUT
++utils/hsc2hs_dist_HC_OPTS         += -DNEW_GHC_LAYOUT -optc-no-pie -optl-no-pie -optP-no-pie
++utils/hsc2hs_dist-install_HC_OPTS += -DNEW_GHC_LAYOUT -optc-no-pie -optl-no-pie -optP-no-pie
+ 
+ utils/hsc2hs_template=$(INPLACE_TOPDIR)/template-hsc.h
+ 
+--- a/utils/ghc-pkg/ghc.mk
++++ b/utils/ghc-pkg/ghc.mk
+@@ -14,6 +14,7 @@
+ # Bootstrapping ghc-pkg
+ 
+ utils/ghc-pkg_dist_PROG = ghc-pkg$(exeext)
++utils/ghc-pkg_dist_HC_OPTS = -optc-no-pie -optl-no-pie -optP-no-pie
+ 
+ ifeq "$(BootingFromHc)" "YES"
+ 
+@@ -47,7 +48,7 @@ endif
+ # depend on ghc-cabal, otherwise we build Cabal twice when building in parallel
+ # The binary package is not warning-clean, so we need a few -fno-warns here.
+ utils/ghc-pkg/dist/build/$(utils/ghc-pkg_dist_PROG)$(exeext): utils/ghc-pkg/Main.hs utils/ghc-pkg/Version.hs $(GHC_CABAL_INPLACE) | bootstrapping/. $$(dir $$@)/.
+-	"$(GHC)" $(SRC_HC_OPTS) --make utils/ghc-pkg/Main.hs -o $@ \
++	"$(GHC)" $(SRC_HC_OPTS) -optc-no-pie -optl-no-pie -optP-no-pie --make utils/ghc-pkg/Main.hs -o $@ \
+ 	       -Wall -fno-warn-unused-imports \
+ 	       -DCABAL_VERSION=$(CABAL_VERSION) \
+ 	       -DBOOTSTRAPPING \
+@@ -88,6 +89,7 @@ utils/ghc-pkg_dist-install_SHELL_WRAPPER
+ utils/ghc-pkg_dist-install_INSTALL_SHELL_WRAPPER = YES
+ utils/ghc-pkg_dist-install_INSTALL_SHELL_WRAPPER_NAME = ghc-pkg-$(ProjectVersion)
+ utils/ghc-pkg_dist-install_INSTALL_INPLACE = NO
++utils/ghc-pkg_dist-install_HC_OPTS = -optc-no-pie -optl-no-pie -optP-no-pie
+ 
+ ifeq "$(BootingFromHc)" "YES"
+ utils/ghc-pkg_dist-install_OTHER_OBJS += $(ALL_STAGE1_LIBS) $(ALL_STAGE1_LIBS) $(ALL_STAGE1_LIBS) $(ALL_RTS_LIBS) $(libffi_STATIC_LIB)
+--- a/utils/genprimopcode/ghc.mk
++++ b/utils/genprimopcode/ghc.mk
+@@ -12,5 +12,6 @@
+ 
+ utils/genprimopcode_dist_MODULES = Lexer Main ParserM Parser Syntax
+ utils/genprimopcode_dist_PROG    = $(GHC_GENPRIMOP_PGM)
++utils/genprimopcode_dist_HC_OPTS = -optc-no-pie -optl-no-pie -optP-no-pie
+ 
+ $(eval $(call build-prog,utils/genprimopcode,dist,0))
+--- a/includes/ghc.mk
++++ b/includes/ghc.mk
+@@ -39,6 +39,8 @@ ifneq "$(GhcWithSMP)" "YES"
+ includes_CC_OPTS += -DNOSMP
+ endif
+ 
++includes_CC_OPTS += -no-pie
++
+ # The fptools configure script creates the configuration header file and puts it
+ # in fptools/mk/config.h. We copy it down to here (without any PACKAGE_FOO
+ # definitions to avoid clashes), prepending some make variables specifying cpp
+@@ -126,6 +128,8 @@ else
+ 
+ includes_dist-derivedconstants_C_SRCS = mkDerivedConstants.c
+ includes_dist-derivedconstants_PROG   = mkDerivedConstants$(exeext)
++includes_dist-derivedconstants_HC_OPTS = -optc-no-pie -optl-no-pie -optP-no-pie
++includes_dist-derivedconstants_CC_OPTS = -no-pie
+ 
+ $(eval $(call build-prog,includes,dist-derivedconstants,0))
+ 
+@@ -154,7 +158,8 @@ else
+ 
+ includes_dist-ghcconstants_C_SRCS = mkDerivedConstants.c
+ includes_dist-ghcconstants_PROG   = mkGHCConstants$(exeext)
+-includes_dist-ghcconstants_CC_OPTS = -DGEN_HASKELL
++includes_dist-ghcconstants_HC_OPTS = -optc-no-pie -optl-no-pie -optP-no-pie
++includes_dist-ghcconstants_CC_OPTS = -DGEN_HASKELL -no-pie
+ 
+ $(eval $(call build-prog,includes,dist-ghcconstants,0))
+ 
+--- a/mk/config.mk.in
++++ b/mk/config.mk.in
+@@ -88,14 +88,14 @@ GhcCompilerWays=
+ #	-dcore-lint	check the types after every pass of the compiler;
+ #			a pretty strong internal check of the compiler being
+ #			used to compile GHC.  Useful when bootstrapping.
+-GhcHcOpts=-Rghc-timing
++GhcHcOpts=-Rghc-timing -optc-no-pie -optl-no-pie -optP-no-pie
+ 
+ # Extra options added to specific stages of the compiler bootstrap.
+ # These are placed later on the command line, and may therefore
+ # override options from $(GhcHcOpts).
+-GhcStage1HcOpts=
+-GhcStage2HcOpts=-O2
+-GhcStage3HcOpts=-O2
++GhcStage1HcOpts=-optc-no-pie -optl-no-pie -optP-no-pie
++GhcStage2HcOpts=-O2 -optc-no-pie -optl-no-pie -optP-no-pie
++GhcStage3HcOpts=-O2 -optc-no-pie -optl-no-pie -optP-no-pie
+ 
+ GhcProfiled=NO
+ GhcDebugged=NO
+@@ -268,7 +268,7 @@ GhcThreaded = $(if $(findstring thr,$(Gh
+ #		but we switch it on for the libraries so that we generate
+ #		the code in case someone importing wants it
+ 
+-GhcLibHcOpts=-O2 -XGenerics
++GhcLibHcOpts=-O2 -XGenerics -optc-no-pie -optl-no-pie -optP-no-pie
+ 
+ # Strip local symbols from libraries?  This can make the libraries smaller,
+ # but makes debugging somewhat more difficult.  Doesn't work with all ld's.
+@@ -317,8 +317,8 @@ CHECK_PACKAGES = NO
+ 
+ # For an optimised RTS (you probably don't want to change these; we build
+ # a debugging RTS by default now.  Use -debug to get it).
+-GhcRtsHcOpts=-optc-O2
+-GhcRtsCcOpts=-fomit-frame-pointer
++GhcRtsHcOpts=-optc-O2 -optc-no-pie -optl-no-pie -optP-no-pie
++GhcRtsCcOpts=-fomit-frame-pointer -no-pie
+ 
+ # Include the front panel code?  Needs GTK+.
+ GhcRtsWithFrontPanel = NO
+@@ -376,7 +376,7 @@ WINDOWS_INSTALLER = $(WINDOWS_INSTALLER_
+ #
+ #	SRC_HC_OPTS += -O
+ 
+-SRC_HC_OPTS += -H32m -O
++SRC_HC_OPTS += -H32m -O -optc-no-pie -optl-no-pie -optP-no-pie
+ 
+ # These flags make flex 8-bit
+ SRC_FLEX_OPTS	+= -8
+@@ -385,7 +385,7 @@ SRC_FLEX_OPTS	+= -8
+ SRC_BLD_DLL_OPTS += --target=i386-mingw32
+ 
+ # Flags for CPP when running GreenCard on .pgc files
+-GC_CPP_OPTS += -P -E -x c -traditional -D__GLASGOW_HASKELL__
++GC_CPP_OPTS += -P -E -x c -traditional -D__GLASGOW_HASKELL__ -no-pie
+ 
+ 
+ # -----------------------------------------------------------------------------
+--- a/ghc/ghc.mk
++++ b/ghc/ghc.mk
+@@ -14,9 +14,9 @@
+ ghc_USES_CABAL = NO
+ # ghc_PACKAGE = ghc-bin
+ 
+-ghc_stage1_HC_OPTS = $(GhcStage1HcOpts)
+-ghc_stage2_HC_OPTS = $(GhcStage2HcOpts)
+-ghc_stage3_HC_OPTS = $(GhcStage3HcOpts)
++ghc_stage1_HC_OPTS = $(GhcStage1HcOpts) -optc-no-pie -optl-no-pie -optP-no-pie
++ghc_stage2_HC_OPTS = $(GhcStage2HcOpts) -optc-no-pie -optl-no-pie -optP-no-pie
++ghc_stage3_HC_OPTS = $(GhcStage3HcOpts) -optc-no-pie -optl-no-pie -optP-no-pie
+ 
+ ifeq "$(GhcWithInterpreter)" "YES"
+ ghc_stage2_HC_OPTS += -DGHCI
+--- a/utils/genapply/ghc.mk
++++ b/utils/genapply/ghc.mk
+@@ -13,7 +13,7 @@
+ utils/genapply_dist_MODULES = GenApply
+ utils/genapply_dist_PROG    = $(GHC_GENAPPLY_PGM)
+ 
+-utils/genapply_HC_OPTS += -package pretty
++utils/genapply_HC_OPTS += -package pretty -optc-no-pie -optl-no-pie -optP-no-pie
+ 
+ ifeq "$(GhcUnregisterised)" "YES"
+ utils/genapply_HC_OPTS += -DNO_REGS
+--- a/utils/hp2ps/ghc.mk
++++ b/utils/hp2ps/ghc.mk
+@@ -17,6 +17,7 @@ utils/hp2ps_dist_C_SRCS = AreaBelow.c Cu
+                           Utilities.c
+ utils/hp2ps_dist_PROG    = hp2ps$(exeext)
+ utils/hp2ps_dist_INSTALL = YES
++utils/hp2ps_dist_HC_OPTS = -optc-no-pie -optl-no-pie -optP-no-pie
+ 
+ $(eval $(call build-prog,utils/hp2ps,dist,0))
+ 
+--- a/utils/hpc/ghc.mk
++++ b/utils/hpc/ghc.mk
+@@ -13,7 +13,7 @@
+ utils/hpc_dist_MODULES = Main HpcCombine HpcDraft HpcFlags HpcLexer HpcMap \
+ 			 HpcMarkup HpcOverlay HpcParser HpcReport HpcSet \
+ 			 HpcShowTix HpcUtils
+-utils/hpc_dist_HC_OPTS = -cpp -package hpc
++utils/hpc_dist_HC_OPTS = -cpp -package hpc -optc-no-pie -optl-no-pie -optP-no-pie
+ utils/hpc_dist_INSTALL = YES
+ utils/hpc_dist_PROG    = hpc$(exeext)
+ $(eval $(call build-prog,utils/hpc,dist,1))
+--- a/utils/runghc/ghc.mk
++++ b/utils/runghc/ghc.mk
+@@ -11,7 +11,7 @@
+ # -----------------------------------------------------------------------------
+ 
+ utils/runghc_dist_MODULES = Main
+-utils/runghc_dist_HC_OPTS = -cpp -DVERSION="\"$(ProjectVersion)\""
++utils/runghc_dist_HC_OPTS = -cpp -DVERSION="\"$(ProjectVersion)\"" -optc-no-pie -optl-no-pie -optP-no-pie
+ utils/runghc_dist_PROG    = runghc$(exeext)
+ utils/runghc_dist_SHELL_WRAPPER = YES
+ utils/runghc_dist_INSTALL_SHELL_WRAPPER = YES
+--- a/mk/ways.mk
++++ b/mk/ways.mk
+@@ -86,7 +86,7 @@ WAY_thr_debug_p_HC_OPTS=-optc-DTHREADED_
+ 
+ # Way 'dyn': build dynamic shared libraries
+ WAY_dyn_NAME=dyn
+-WAY_dyn_HC_OPTS=-fPIC -dynamic
++WAY_dyn_HC_OPTS=-fPIC -dynamic -optc-no-pie -optl-no-pie -optP-no-pie
+ 
+ # Way 'thr_dyn':
+ WAY_thr_dyn_NAME=thr_dyn
+--- a/mk/custom-settings.mk
++++ b/mk/custom-settings.mk
+@@ -12,3 +12,4 @@ ifeq "$(BINDIST)" "YES"
+ -include bindist.mk
+ endif
+ 
++SRC_HC_OPTS += -optc-no-pie -optl-no-pie -optP-no-pie
+--- a/rts/ghc.mk
++++ b/rts/ghc.mk
+@@ -15,6 +15,7 @@
+ 
+ # We build the RTS with stage 1
+ rts_dist_HC = $(GHC_STAGE1)
++rts_dist_HC_OPTS = -optc-no-pie -optl-no-pie -optP-no-pie
+ 
+ # merge GhcLibWays and GhcRTSWays but strip out duplicates
+ rts_WAYS = $(GhcLibWays) $(filter-out $(GhcLibWays),$(GhcRTSWays))
+@@ -172,9 +173,9 @@ STANDARD_OPTS += -DCOMPILING_RTS
+ # must be included in both types of compilations.
+ 
+ rts_CC_OPTS += $(WARNING_OPTS)
+-rts_CC_OPTS += $(STANDARD_OPTS)
++rts_CC_OPTS += $(STANDARD_OPTS) -no-pie
+ 
+-rts_HC_OPTS += $(STANDARD_OPTS) -package-name rts
++rts_HC_OPTS += $(STANDARD_OPTS) -package-name rts -optc-no-pie -optl-no-pie -optP-no-pie
+ 
+ ifneq "$(GhcWithSMP)" "YES"
+ rts_CC_OPTS += -DNOSMP

--- a/recipes-devtools/ghc/files/force-ghc-to-compile-code-with-no-pie.patch
+++ b/recipes-devtools/ghc/files/force-ghc-to-compile-code-with-no-pie.patch
@@ -1,0 +1,41 @@
+This is inspired from the Debian GHC patch "no-pie", found in:
+http://deb.debian.org/debian/pool/main/g/ghc/ghc_8.0.1-17.debian.tar.xz
+More information there, but this basically fixes linking of some haskell
+components on recent compilers/distros.
+
+--- a/compiler/main/DynFlags.hs
++++ b/compiler/main/DynFlags.hs
+@@ -2332,7 +2332,8 @@ machdepCCOpts _dflags
+                         -- built-in functions like memcpy() it tends to
+                         -- run out of registers, requiring -monly-n-regs
+                         "-fno-builtin",
+-                        "-DSTOLEN_X86_REGS="++show n_regs ]
++                        "-DSTOLEN_X86_REGS="++show n_regs,
++                        "-no-pie" ]
+                     )
+ 
+ #elif ia64_TARGET_ARCH
+@@ -2351,10 +2352,11 @@ machdepCCOpts _dflags
+                         -- and get in the way of -split-objs.  Another option
+                         -- would be to throw them away in the mangler, but this
+                         -- is easier.
+-                 "-fno-builtin"
++                 "-fno-builtin",
+                         -- calling builtins like strlen() using the FFI can
+                         -- cause gcc to run out of regs, so use the external
+                         -- version.
++                 "-no-pie"
+                 ] )
+ 
+ #elif sparc_TARGET_ARCH
+--- a/compiler/main/DriverPipeline.hs
++++ b/compiler/main/DriverPipeline.hs
+@@ -1685,7 +1685,7 @@ linkDynLib dflags o_files dep_packages =
+ 	 ++ map SysTools.Option (
+ 	    md_c_flags
+ 	 ++ o_files
+-	 ++ [ "-shared", "-Wl,-Bsymbolic" ] -- we need symbolic linking to resolve non-PIC intra-package-relocations
++	 ++ [ "-no-pie", "-shared", "-Wl,-Bsymbolic" ] -- we need symbolic linking to resolve non-PIC intra-package-relocations
+          ++ [ "-Wl,-soname," ++ takeFileName output_fn ] -- set the library soname
+ 	 ++ extra_ld_inputs
+ 	 ++ lib_path_opts

--- a/recipes-devtools/ghc/files/rts-no-hidden.patch
+++ b/recipes-devtools/ghc/files/rts-no-hidden.patch
@@ -1,0 +1,23 @@
+Those 2 lines are incorrect, a #define cannot contain a #pragma.
+See: https://gcc.gnu.org/onlinedocs/gcc-8.3.0/cpp/Pragmas.html
+This was seemingly ignored by previous versions of GCC but it now breaks compilation.
+
+The instances of "#pragma" could be replaced by "_Pragma()", as suggested under the
+URL above, but that actually breaks xenmgr, which uses some of the functions that
+would otherwise be hidden.
+
+Doing nothing replicates previous behavior and fixes the issue.
+
+--- a/includes/Rts.h
++++ b/includes/Rts.h
+@@ -58,8 +58,8 @@ extern "C" {
+ #endif
+ 
+ #if __GNUC__ > 4
+-#define BEGIN_RTS_PRIVATE #pragma GCC visibility push(hidden)
+-#define END_RTS_PRIVATE   #pragma GCC visibility pop
++#define BEGIN_RTS_PRIVATE
++#define END_RTS_PRIVATE
+ #else
+ #define BEGIN_RTS_PRIVATE /* disabled: BEGIN_RTS_PRIVATE */
+ #define END_RTS_PRIVATE   /* disabled: END_RTS_PRIVATE */

--- a/recipes-devtools/ghc/ghc-6.12.3.inc
+++ b/recipes-devtools/ghc/ghc-6.12.3.inc
@@ -18,6 +18,9 @@ SRC_URI = " \
     file://0007-x64-more-stack.patch \
     file://0008-7919-large-objects.patch \
     file://0009-Fix-segfault-in-retainer-profiling-when-using-multiple-cores-5909.patch \
+    file://compile-ghc-with-no-pie.patch \
+    file://force-ghc-to-compile-code-with-no-pie.patch \
+    file://rts-no-hidden.patch \
 "
 SRC_URI[md5sum] = "4c2663c2eff833d7b9f39ef770eefbd6"
 SRC_URI[sha256sum] = "6cbdbe415011f2c7d15e4d850758d8d393f70617b88cb3237d2c602bb60e5e68"

--- a/recipes-devtools/ghc/ghc-native_6.12.3.bb
+++ b/recipes-devtools/ghc/ghc-native_6.12.3.bb
@@ -9,19 +9,6 @@ require ghc-${PV}.inc
 # http://www.edsko.net/2013/02/10/comprehensive-haskell-sandboxes/ to separate
 # the installation from the host rootfs.
 #
-# Static libraries are not -fPIC, This makes x86_64 attempts to build the
-# compiler fail miserably, example using the binary package with an HelloWord:
-#
-#   Hello.hs:main = putStrLn "Hello, World!"
-#
-#   $ ghc -dynamic -o hello Hello.hs
-#   /usr/bin/ld: warning: libgmp.so.3, needed by /home/user/.ghc-env/ghc6-x86_64/local//lib/ghc-6.12.3/haskell98-1.0.1.1/libHShaskell98-1.0.1.1-ghc6.12.3.so, may conflict with libgmp.so.10
-#   /usr/bin/ld: /home/user/.ghc-env/ghc6-x86_64/local//lib/ghc-6.12.3/libHSrtsmain.a(Main.o): relocation R_X86_64_32 against symbol `ZCMain_main_closure' can not be used when making a shared object; recompile with -fPIC
-#   /usr/bin/ld: Hello.o: relocation R_X86_64_PC32 against symbol `newCAF' can not be used when making a shared object; recompile with -fPIC
-#   /usr/bin/ld: final link failed: Bad value
-#   collect2: error: ld returned 1 exit status
-#
-# This will have to be dealt with later.
 
 do_configure() {
     ./configure --prefix=${prefix} --enable-shared

--- a/recipes-devtools/hackage/hkg-haxml/no-pie.patch
+++ b/recipes-devtools/hackage/hkg-haxml/no-pie.patch
@@ -1,0 +1,67 @@
+--- a/HaXml.cabal
++++ b/HaXml.cabal
+@@ -66,50 +66,50 @@ library
+   nhc98-options: -K10M
+ 
+ Executable Canonicalise
+-  GHC-Options: -Wall
++  GHC-Options: -Wall -optc-no-pie -optl-no-pie -optP-no-pie
+   Extensions:  CPP
+   Hs-Source-Dirs: src/tools, src
+-  cpp-options: -DMYVERSION="1.20.2"
++  cpp-options: -DMYVERSION="1.20.2" -no-pie
+   Main-Is: Canonicalise.hs
+ 
+ Executable CanonicaliseLazy
+-  GHC-Options: -Wall
++  GHC-Options: -Wall -optc-no-pie -optl-no-pie -optP-no-pie
+   Extensions:  CPP
+   Hs-Source-Dirs: src/tools, src
+-  cpp-options: -DMYVERSION="1.20.2"
++  cpp-options: -DMYVERSION="1.20.2" -no-pie
+   Main-Is: CanonicaliseLazy.hs
+ 
+ Executable Xtract
+-  GHC-Options: -Wall
++  GHC-Options: -Wall -optc-no-pie -optl-no-pie -optP-no-pie
+   Extensions:  CPP
+   Hs-Source-Dirs: src/tools, src
+-  cpp-options: -DMYVERSION="1.20.2"
++  cpp-options: -DMYVERSION="1.20.2" -no-pie
+   Main-Is: Xtract.hs
+ 
+ Executable XtractLazy
+-  GHC-Options: -Wall
++  GHC-Options: -Wall -optc-no-pie -optl-no-pie -optP-no-pie
+   Extensions:  CPP
+   Hs-Source-Dirs: src/tools, src
+-  cpp-options: -DMYVERSION="1.20.2"
++  cpp-options: -DMYVERSION="1.20.2" -no-pie
+   Main-Is: XtractLazy.hs
+ 
+ Executable Validate
+-  GHC-Options: -Wall
++  GHC-Options: -Wall -optc-no-pie -optl-no-pie -optP-no-pie
+   Extensions:  CPP
+   Hs-Source-Dirs: src/tools, src
+-  cpp-options: -DMYVERSION="1.20.2"
++  cpp-options: -DMYVERSION="1.20.2" -no-pie
+   Main-Is: Validate.hs
+ 
+ Executable MkOneOf
+-  GHC-Options: -Wall
++  GHC-Options: -Wall -optc-no-pie -optl-no-pie -optP-no-pie
+   Extensions:  CPP
+   Hs-Source-Dirs: src/tools, src
+-  cpp-options: -DMYVERSION="1.20.2"
++  cpp-options: -DMYVERSION="1.20.2" -no-pie
+   Main-Is: MkOneOf.hs
+ 
+ Executable DtdToHaskell
+-  GHC-Options: -Wall
++  GHC-Options: -Wall -optc-no-pie -optl-no-pie -optP-no-pie
+   Extensions:  CPP
+   Hs-Source-Dirs: src/tools, src
+-  cpp-options: -DMYVERSION="1.20.2"
++  cpp-options: -DMYVERSION="1.20.2" -no-pie
+   Main-Is: DtdToHaskell.hs

--- a/recipes-devtools/hackage/hkg-haxml_1.20.2.bb
+++ b/recipes-devtools/hackage/hkg-haxml_1.20.2.bb
@@ -5,6 +5,8 @@ LIC_FILES_CHKSUM = "file://COPYRIGHT;md5=b84b8bea272e7357c5c7fe6f255ba732"
 HPN = "HaXml"
 inherit hackage
 
+SRC_URI += 'file://no-pie.patch'
+
 SRC_URI[md5sum] = "9635c348e70c0446e74783e7c267050c"
 SRC_URI[sha256sum] = "c32c10b95446ecb938dc6cd34585187efd3fcb4b21f7d0c7cbd646ba94c87516"
 DEPENDS += "hkg-polyparse"

--- a/recipes-devtools/hackage/hkg-vhd/no-pie.patch
+++ b/recipes-devtools/hackage/hkg-vhd/no-pie.patch
@@ -1,0 +1,10 @@
+--- a/vhd.cabal
++++ b/vhd.cabal
+@@ -64,6 +64,7 @@ Executable           vhd
+     Build-depends:   base >= 3 && < 5
+   else
+     Buildable:       False
++  GHC-Options: -optc-no-pie -optl-no-pie -optP-no-pie
+ 
+ source-repository head
+   type:     git

--- a/recipes-devtools/hackage/hkg-vhd_0.2.bb
+++ b/recipes-devtools/hackage/hkg-vhd_0.2.bb
@@ -6,6 +6,8 @@ EXTRA_CABAL_CONF += "--flag=executable"
 
 inherit hackage
 
+SRC_URI += " file://no-pie.patch "
+
 SRC_URI[md5sum] = "4d727ca01e55884d642613593edb47f5"
 SRC_URI[sha256sum] = "f15dd0127cbaaaa3fef69bfde6e2ac8b83e9d3a0295bf94de8c0c9e8c928e375"
 DEPENDS += " \


### PR DESCRIPTION
Use -no-pie for ghc itself and as a default flag for what ghc compiles.

OXT-1706

Signed-off-by: Jed <lejosnej@ainfosec.com>