### PR TITLE
ghc-runtime: Prevent race at header installation

### DIFF
--- a/recipes-devtools/ghc/files/template-hsc-install-race.patch
+++ b/recipes-devtools/ghc/files/template-hsc-install-race.patch
@@ -1,0 +1,10 @@
+--- a/utils/hsc2hs/ghc.mk
++++ b/utils/hsc2hs/ghc.mk
+@@ -54,6 +54,7 @@ install: install_utils/hsc2hs_dist_insta
+ 
+ .PHONY: install_utils/hsc2hs_dist_install
+ install_utils/hsc2hs_dist_install: utils/hsc2hs/template-hsc.h
++	$(INSTALL_DIR) "$(DESTDIR)$(topdir)"
+ 	$(INSTALL_HEADER) $(INSTALL_OPTS) $< "$(DESTDIR)$(topdir)"
+ 
+ BINDIST_EXTRAS += utils/hsc2hs/template-hsc.h

--- a/recipes-devtools/ghc/ghc-6.12.3.inc
+++ b/recipes-devtools/ghc/ghc-6.12.3.inc
@@ -21,6 +21,7 @@ SRC_URI = " \
     file://compile-ghc-with-no-pie.patch \
     file://force-ghc-to-compile-code-with-no-pie.patch \
     file://rts-no-hidden.patch \
+    file://template-hsc-install-race.patch \
 "
 SRC_URI[md5sum] = "4c2663c2eff833d7b9f39ef770eefbd6"
 SRC_URI[sha256sum] = "6cbdbe415011f2c7d15e4d850758d8d393f70617b88cb3237d2c602bb60e5e68"


### PR DESCRIPTION
Rarely, ghc-runtime will fail its do_install step with:
```
| .../tmp-glibc/hosttools/install: cannot create directory ‘.../tmp-glibc/work/core2-64-oe-linux/ghc-runtime/6.12.3-r0/image/usr/lib/ghc-6.12.3’: Not a directory
```
This looks like a Makefile race, the install rule is called with `-j 8`:
```
make -j 8 install DESTDIR=.../tmp-glibc/work/core2-64-oe-linux/ghc-runtime/6.12.3-r0/image
```
Yet template-hsc.h assumes the destination directory (`${DESTDIR}/usr/lib/ghc-6.12.3`) exists. If it does not the header will be created as the file named `"${DESTDIR}/usr/lib/ghc-6.12.3"` which is what we see in DESTDIR when do_install fails.

Make sure the directory is created before installing the header.