### PR TITLE
haskell: Attend build failures with externalsrc setup

### DIFF
--- a/classes/haskell.bbclass
+++ b/classes/haskell.bbclass
@@ -41,7 +41,7 @@ FILES_${PN}-dev_append = " \
 RUNGHC = "runghc"
 # Use a local copy of the database to keep control over what is in the sysroot.
 GHC_PACKAGE_DATABASE = "local-packages.db"
-export GHC_PACKAGE_PATH = "${S}/${GHC_PACKAGE_DATABASE}"
+export GHC_PACKAGE_PATH = "${B}/${GHC_PACKAGE_DATABASE}"
 
 do_update_local_pkg_database() {
     # Build the local package database for runghc to process dependencies.
@@ -53,7 +53,6 @@ do_update_local_pkg_database() {
 # database. runghc will not be able to process dependencies otherwise, neither
 # will ghc-pkg be there if not installed on the host.
 addtask do_update_local_pkg_database before do_configure after do_prepare_recipe_sysroot
-do_update_local_pkg_database[depends] = "${PN}:do_unpack"
 do_update_local_pkg_database[doc] = "Put together a local Haskell package database for runghc to use, and amend configuration to match bitbake environment."
 # See: bitbake.git: 67a7b8b0 build: don't use $B as the default cwd for functions
 do_update_local_pkg_database[dirs] = "${B}"

--- a/classes/haskell.bbclass
+++ b/classes/haskell.bbclass
@@ -181,10 +181,10 @@ do_install() {
     ${RUNGHC} Setup.*hs copy --copy-prefix="${D}/${prefix}" --verbose
 
     # Prepare GHC package database files.
-    if [ -f "${S}/${HPN}-${HPV}.conf" ]; then
+    if [ -f "${B}/${HPN}-${HPV}.conf" ]; then
         ghc_version=$(ghc-pkg --version)
         ghc_version=${ghc_version##* }
         install -m 755 -d ${D}${libdir}/ghc-${ghc_version}/package.conf.d
-        install -m 644 ${S}/${HPN}-${HPV}.conf ${D}${libdir}/ghc-${ghc_version}/package.conf.d
+        install -m 644 ${B}/${HPN}-${HPV}.conf ${D}${libdir}/ghc-${ghc_version}/package.conf.d
     fi
 }


### PR DESCRIPTION
Generate the package database in `${B}` instead of `${S}` and drop the dependency 
of `do_update_local_pkg_database` on `do_unpack`.

`externalsrc` will remove `do_unpack`, breaking haskell recipes. There is technically no reason to have the `do_update_local_pkg_database` depend on `do_unpack` since the database is generated from files in the recipe-sysroot.