### PR TITLE
OXT-1317: haskell: step dependencies and out-of-tree builds

### DIFF
--- a/classes/hackage.bbclass
+++ b/classes/hackage.bbclass
@@ -12,3 +12,7 @@ BBCLASSEXTEND = "native"
 HPN ?= "${@d.getVar("BPN", True).split("hkg-", 1)[1]}"
 
 inherit haskell
+
+CONFIGURE_FILES += " \
+    ${S}/${HPN}-${HPV}.conf \
+"

--- a/classes/haskell.bbclass
+++ b/classes/haskell.bbclass
@@ -39,50 +39,26 @@ FILES_${PN}-dev_append = " \
 "
 
 RUNGHC = "runghc"
-# Use a local copy of the database to keep control over what is in the sysroot.
-GHC_PACKAGE_DATABASE = "local-packages.db"
-export GHC_PACKAGE_PATH = "${S}/${GHC_PACKAGE_DATABASE}"
 
-do_update_local_pkg_database() {
-    # Build the local package database for runghc to process dependencies.
-    rm -rf "${GHC_PACKAGE_DATABASE}"
-    ghc-pkg init "${GHC_PACKAGE_DATABASE}"
-}
-# Run after do_prepare_recipe_sysroot to ensure that the recipe's sysroot is
-# populated by every item in DEPENDS before we update the local package
-# database. runghc will not be able to process dependencies otherwise, neither
-# will ghc-pkg be there if not installed on the host.
-addtask do_update_local_pkg_database before do_configure after do_prepare_recipe_sysroot
-do_update_local_pkg_database[depends] = "${PN}:do_unpack"
-do_update_local_pkg_database[doc] = "Put together a local Haskell package database for runghc to use, and amend configuration to match bitbake environment."
-# See: bitbake.git: 67a7b8b0 build: don't use $B as the default cwd for functions
-do_update_local_pkg_database[dirs] = "${B}"
+GHC_PACKAGE_PATH_class-native = "${STAGING_LIBDIR_NATIVE}/ghc-6.12.3/package.conf.d"
+GHC_PACKAGE_PATH_class-target = "${STAGING_LIBDIR}/ghc-6.12.3/package.conf.d"
+export GHC_PACKAGE_PATH
 
-do_update_local_pkg_database_append_class-target() {
+# Bitbake will amend the WORKDIR paths it finds (staging stage 2). This works to
+# our advantage for native class, target class need to be configured with their
+# target dependencies, so substitute the target paths for WORKDIR starging so
+# ghc-pkg finds them.
+do_configure_prepend_class-target() {
     ghc_version=$(ghc-pkg --version)
     ghc_version=${ghc_version##* }
     for pkgconf in ${STAGING_LIBDIR}/ghc-${ghc_version}/package.conf.d/*.conf; do
         if [ -f "${pkgconf}" ]; then
-            sed -e "s| /usr/lib| ${STAGING_LIBDIR}|" \
+            sed -i \
+                -e "s| /usr/lib| ${STAGING_LIBDIR}|" \
                 -e "s| /usr/include| ${STAGING_INCDIR}|" \
-                $pkgconf | \
-            ghc-pkg -f "${GHC_PACKAGE_DATABASE}" --force update -
+                $pkgconf
         fi
     done
-    ghc-pkg -f "${GHC_PACKAGE_DATABASE}" recache
-}
-do_update_local_pkg_database_append_class-native() {
-    ghc_version=$(ghc-pkg --version)
-    ghc_version=${ghc_version##* }
-    for pkgconf in ${STAGING_LIBDIR_NATIVE}/ghc-${ghc_version}/package.conf.d/*.conf; do
-        if [ -f "${pkgconf}" ]; then
-            sed -e "s| /usr/lib| ${STAGING_LIBDIR_NATIVE}|" \
-                -e "s| /usr/include| ${STAGING_INCDIR_NATIVE}|" \
-                $pkgconf | \
-            ghc-pkg -f "${GHC_PACKAGE_DATABASE}" --force update -
-        fi
-    done
-    ghc-pkg -f "${GHC_PACKAGE_DATABASE}" recache
 }
 
 # This is oddly required because there is no good way to pass ${CC} as set
@@ -101,16 +77,17 @@ exec ${CCLD} ${LDFLAGS} "\$@"
 EOF
     chmod +x ghc-ld
 }
-addtask do_makeup_wrappers before do_configure after do_patch
 do_makeup_wrappers[doc] = "Generate local wrappers for the compiler to pass bitbake environment through ghc."
 do_makeup_wrappers[dirs] = "${B}"
+do_configure[prefuncs] += "do_makeup_wrappers"
 
 do_configure() {
+    ghc-pkg recache
+
     ${RUNGHC} Setup.*hs clean --verbose
     ${RUNGHC} Setup.*hs configure \
         ${EXTRA_CABAL_CONF} \
         --disable-executable-stripping \
-        --package-db="${GHC_PACKAGE_DATABASE}" \
         --ghc-options='-dynload sysdep
                        -pgmc ./ghc-cc
                        -pgml ./ghc-ld' \
@@ -182,10 +159,10 @@ do_install() {
     ${RUNGHC} Setup.*hs copy --copy-prefix="${D}/${prefix}" --verbose
 
     # Prepare GHC package database files.
-    if [ -f "${S}/${HPN}-${HPV}.conf" ]; then
+    if [ -f "${B}/${HPN}-${HPV}.conf" ]; then
         ghc_version=$(ghc-pkg --version)
         ghc_version=${ghc_version##* }
         install -m 755 -d ${D}${libdir}/ghc-${ghc_version}/package.conf.d
-        install -m 644 ${S}/${HPN}-${HPV}.conf ${D}${libdir}/ghc-${ghc_version}/package.conf.d
+        install -m 644 ${B}/${HPN}-${HPV}.conf ${D}${libdir}/ghc-${ghc_version}/package.conf.d
     fi
 }

--- a/classes/haskell.bbclass
+++ b/classes/haskell.bbclass
@@ -38,6 +38,12 @@ FILES_${PN}-dev_append = " \
     ${libdir}/${HPN}-${HPV}/ghc-*/* \
 "
 
+CONFIGURE_FILES += " \
+    ${S}/Setup.hs \
+    ${S}/Setup.lhs \
+    ${S}/${HPN}.cabal \
+"
+
 RUNGHC = "runghc"
 
 GHC_PACKAGE_PATH_class-native = "${STAGING_LIBDIR_NATIVE}/ghc-6.12.3/package.conf.d"

--- a/recipes-devtools/ghc/files/ghc-cc
+++ b/recipes-devtools/ghc/files/ghc-cc
@@ -1,0 +1,2 @@
+#! /bin/sh
+exec ${CC} ${CFLAGS} "$@"

--- a/recipes-devtools/ghc/files/ghc-ld
+++ b/recipes-devtools/ghc/files/ghc-ld
@@ -1,0 +1,2 @@
+#! /bin/sh
+exec ${CCLD} ${LDFLAGS} "$@"

--- a/recipes-devtools/ghc/ghc-native_6.12.3.bb
+++ b/recipes-devtools/ghc/ghc-native_6.12.3.bb
@@ -1,6 +1,14 @@
 inherit native
 require ghc-${PV}.inc
 
+# This is oddly required because there is no good way to pass ${CC} as set per
+# bitbake to runghc. One might think of using --ghc-options="-pgmc ${CC%% *}
+# -otpc ${CC#* }", but it does not manage to parse the options correctly...
+SRC_URI += " \
+    file://ghc-cc \
+    file://ghc-ld \
+"
+
 # This requires a ghc6 capable compiler to be already installed on the host in
 # order to bootstrap the build.
 # ghc-6.12.3 can be found: https://www.haskell.org/ghc/download_ghc_6_12_3.html
@@ -13,4 +21,9 @@ require ghc-${PV}.inc
 do_configure() {
     ./configure --prefix=${prefix} --enable-shared
     echo "STANDARD_OPTS += \"-I${STAGING_INCDIR_NATIVE}\"" >> rts/ghc.mk
+}
+
+do_install_append() {
+    install -m 755 "${WORKDIR}/ghc-cc" "${D}${bindir}/ghc-cc"
+    install -m 755 "${WORKDIR}/ghc-ld" "${D}${bindir}/ghc-ld"
 }


### PR DESCRIPTION
`externalsrc.bbclass` removes `do_fetch`, `do_unpack` and `do_patch`, so these cannot be used to set dependencies like `haskell.bbclass` is doing, or the class will break under `externalsrc`.

In the end, the sysroot already is populated with a package database and bitbake will even handle path substitutions for native targets in the database (see Staging, stage 2).

There are only minor quirks for target classes that needs to be taken care of and can be taken care of by prepending the configure step. This has both advantage of not requiring new steps dependencies and relies on bitbake managing the sysroot using the sstate to maintain configuration
sanity.

A common example of corruption happens when using externalsrc and clobbering a version-controlled repository, removing local configuration files in S.

As well, `ghc-cc`/`ghc-ld` helper scripts do not need to be generated for each recipe, instead rely on a recipe providing the two wrappers for `ghc-native` to use.

Requires: https://github.com/OpenXT/xenclient-oe/pull/1346