### PR TITLE
layer: switch compatibility to dunfell.

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -18,7 +18,7 @@ BBFILE_PRIORITY_meta-openxt-haskell-platform = "9"
 LICENSE_PATH += "${LAYERDIR}/files/additional-licenses"
 
 LAYERVERSION_meta-openxt-haskell-platform = "1"
-LAYERSERIES_COMPAT_meta-openxt-haskell-platform = "zeus"
+LAYERSERIES_COMPAT_meta-openxt-haskell-platform = "dunfell"
 
 
 HOSTTOOLS += " \


### PR DESCRIPTION
Switch layer compatibility to dunfell.
Since this layer maintains a `zeus` branch, remove `zeus` from the compatibility list to not intend backward compatibility.

Required by: github.com/OpenXT/xenclient-oe/pull/1355