### PR TITLE
hkg-split: add recipe

### DIFF
--- a/recipes-devtools/hackage/hkg-split_0.1.4.3.bb
+++ b/recipes-devtools/hackage/hkg-split_0.1.4.3.bb
@@ -1,0 +1,8 @@
+DESCRIPTION = "A collection of various methods for splitting lists into parts, akin to the "split" function found in several mainstream languages."
+LICENSE = "BSD-3-Clause"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=6994c17380b45ebadfe3efa7507ad3da"
+
+inherit hackage
+
+SRC_URI[md5sum] = "2a19f1dca98be53b5f4c5dd535a65ca3"
+SRC_URI[sha256sum] = "7e69989206e26bb28f46cc8cf1edff5e439aa6be4adbc5b09118d6fdc1aa3bc5"


### PR DESCRIPTION
0.1.4.3 is the latest release that was supported for GHC6.
This is a new dependency introduced to xenmgr for handling vglass components.