### PR TITLE
haskell.bbclass: Disable PIE for security flags

### DIFF
--- a/classes/haskell.bbclass
+++ b/classes/haskell.bbclass
@@ -50,6 +50,11 @@ GHC_PACKAGE_PATH_class-native = "${STAGING_LIBDIR_NATIVE}/ghc-6.12.3/package.con
 GHC_PACKAGE_PATH_class-target = "${STAGING_LIBDIR}/ghc-6.12.3/package.conf.d"
 export GHC_PACKAGE_PATH
 
+# GHC has been patched to disable generating PIE code, so we need to disable
+# PIE to be able to link any haskell programs.
+SECURITY_CFLAGS = "${SECURITY_NOPIE_CFLAGS}"
+SECURITY_LDFLAGS = ""
+
 # Bitbake will amend the WORKDIR paths it finds (staging stage 2). This works to
 # our advantage for native class, target class need to be configured with their
 # target dependencies, so substitute the target paths for WORKDIR starging so


### PR DESCRIPTION
GHC is already patched to avoid generating PIE code since there are
linking issues.  For security_flags, we can't use PIE either since we
will fail to link.  Instead of creating a list of all haskell packages
in the openxt-main distro, override the security flags here.

Signed-off-by: Jason Andryuk <jandryuk@gmail.com>